### PR TITLE
fix inventory sorting to utilize burnable items list

### DIFF
--- a/mine.lua
+++ b/mine.lua
@@ -974,7 +974,7 @@ local slots = (function()
 		local desc = {
 			[CHEST_SLOT] = "Chests",
 			[BLOCK_SLOT] = "Cobblestone",
-			[FUEL_SLOT] = "Fuel (only coal supported)",
+			[FUEL_SLOT] = "Fuel (supports items from BURNABLE_ITEMS list)",
 			[FUEL_CHEST_SLOT] = "Fuel Entangled Chest",
 			[CHUNK_LOADER_SLOT] = "2 Chunk Loaders",
 		}

--- a/mine.lua
+++ b/mine.lua
@@ -99,6 +99,13 @@ local FALLING_BLOCKS = {
 	["minecraft:sand"] = true
 }
 
+local BURNABLE_ITEMS = {
+	["minecraft:coal"] = true,
+	["minecraft:coal_block"] = true,
+	["minecraft:charcoal"] = true,
+	["minecraft:blaze_rod"] = true
+}
+
 --#endregion
 --#region WRAPPER----
 
@@ -1501,7 +1508,7 @@ local function sortInventory(sortFuel)
 	--clear fuel slot
 	if sortFuel then
 		local initFuelData = wrapt.getItemDetail(slots.get(FUEL_SLOT))
-		if initFuelData and initFuelData.name ~= "minecraft:coal" then
+		if initFuelData and not BURNABLE_ITEMS[initFuelData.name] then
 			wrapt.select(slots.get(FUEL_SLOT))
 			wrapt.drop()
 		end
@@ -1522,7 +1529,7 @@ local function sortInventory(sortFuel)
 			if curData.name == "minecraft:cobblestone" then
 				wrapt.select(i)
 				wrapt.transferTo(slots.get(BLOCK_SLOT))
-			elseif sortFuel and curData.name == "minecraft:coal" then
+			elseif sortFuel and BURNABLE_ITEMS[curData.name] then
 				wrapt.select(i)
 				wrapt.transferTo(slots.get(FUEL_SLOT))
 			end

--- a/mine.lua
+++ b/mine.lua
@@ -20,7 +20,7 @@ cfg.localConfig = {
 	--tested with chests from https://www.curseforge.com/minecraft/mc-mods/kibe
 	useEntangledChests = false,
 	--false: refuel from inventory, true: refuel from (a different) entangled chest
-	--if true, the turtle won't store any coal. Instead, when refueling, it will place the entangled chest, grab fuel from it, refuel, and then break the chest.
+	--if true, the turtle won't store any fuel. Instead, when refueling, it will place the entangled chest, grab fuel from it, refuel, and then break the chest.
 	useFuelEntangledChest = false,
 	--true: use two chuck loaders to mine indefinitely without moving into unloaded chunks. 
 	--This doesn't work with chunk loaders from https://www.curseforge.com/minecraft/mc-mods/kibe, but might work with some other mod.

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,9 @@ This program is capable of mining an arbitrary area while removing lava, automat
 
 1. Run `pastebin get 7uHd9pPx mine`. Run `mine`.
 1. On startup, the program shows a bunch of info, such as fuel level, slots used for various items, etc.
-1. By default, three slots are assigned: Chests, Coal and Cobblestone.
-Chests are required since they are used to drop off mined items, but the cobblestone and coal slots can be left empty.
-The turtle will store collected coal and cobblestone in those slots and use them when necessary.
+1. By default, three slots are assigned: Chests, Fuel and Cobblestone.
+Chests are required since they are used to drop off mined items, but the cobblestone and fuel slots can be left empty.
+The turtle will store collected fuel and cobblestone in those slots and use them when necessary.
 1. Below that, you will see a list of programs.
 You can run `help <program>` to get a description of any specific program.
 1. Let's assume you want the turtle to branch mine.


### PR DESCRIPTION
Expand fuel options for turtle refueling beyond coal by introducing a burnable items list.