### PR TITLE
Charcoal found to be supported

### DIFF
--- a/mine.lua
+++ b/mine.lua
@@ -967,7 +967,7 @@ local slots = (function()
 		local desc = {
 			[CHEST_SLOT] = "Chests",
 			[BLOCK_SLOT] = "Cobblestone",
-			[FUEL_SLOT] = "Fuel (only coal supported)",
+			[FUEL_SLOT] = "Fuel (only coal and charcoal supported)",
 			[FUEL_CHEST_SLOT] = "Fuel Entangled Chest",
 			[CHUNK_LOADER_SLOT] = "2 Chunk Loaders",
 		}


### PR DESCRIPTION
This PR adds the text that charcoal is supported, as in CC: Tweaked version 1.113.1 an advanced mining turtle took charcoal just fine in place of coal. Untested right now if other fuel sources work as well.